### PR TITLE
[Feature] Added GATT service for Connection, Utilized RTOS queue, updated BLE to send ECG data 

### DIFF
--- a/src/ble_service.cpp
+++ b/src/ble_service.cpp
@@ -96,9 +96,9 @@ BLEInitStatus initBLE() {
   return BLEInitStatus::SUCCESS;
 }
 
-void updateBLE(unsigned long seconds) {
+void updateBLE(uint16_t ecg_data) {
   if (deviceConnected && ecg_characteristic) {
-    String msg = "Uptime: " + String(seconds) + "s";
+    String msg = "ECG data: " + String(ecg_data);
     ecg_characteristic->setValue(msg.c_str());
     ecg_characteristic->notify();
     Serial.println(msg);

--- a/src/ble_service.h
+++ b/src/ble_service.h
@@ -12,7 +12,7 @@ enum class BLEInitStatus {
 };
 
 BLEInitStatus initBLE();
-void updateBLE(unsigned long seconds);
+void updateBLE(uint16_t ecg_data);
 extern bool deviceConnected;
 
 #endif

--- a/src/rtos_tasks.cpp
+++ b/src/rtos_tasks.cpp
@@ -6,7 +6,6 @@
 
 
 // SHARED VALUE between cores. Just a test.
-volatile unsigned long currentMillis = 0;
 float ecg_sample;
 float filtered_ecg = 0.0;
 
@@ -37,8 +36,7 @@ void TaskBLE(void* pvParameters) {
       Serial.printf("[BLE Task] ECG value sent: %u\n", ecg_value);
     }
 
-    // Update BLE every second (or adjust as needed)
-    updateBLE(currentMillis / 1000);
+    updateBLE(ecg_value);
 
     // 50 ticks was chosen to allow the BLE task time to see data before TaskECG could flood the queue.  
     vTaskDelay(pdMS_TO_TICKS(50));
@@ -69,8 +67,6 @@ void TaskECG(void* pvParameters) {
         Serial.printf(">kalmanVal:%.2f\n", kalman_ecg);
         last_print = millis();
       }
-
-      currentMillis = millis();
       // Converts a 32 bit float into a 16 bit int. May modify ecg_sample's type.
       uint16_t converted_sample = (uint16_t)(kalman_ecg * 1000);
       if( xQueueSend(ble_queue, &converted_sample, 0) != pdTRUE) {


### PR DESCRIPTION
## Discussion
I decided to add another GATT service for connection status - it'd be nice to let the client know when the peripheral either connects or disconnects to handle both situations client-side. Alongside that, I decided to use an RTOS queue to avoid an issue of flooding the Bluetooth chip with requests. I will implement batching the ECG data in the next branch.

- Added `ConnectionStatus` GATT service to send the connection status the peripheral has.
- Renamed the generic-Ly named `pCharacteristic` and associated values to be `ecg_(service/characteristic`
- Added an RTOS queue to aid in batching for next branch
- Connected ECG data to be sent over BLE. Images below.
<img width="271" height="193" alt="image" src="https://github.com/user-attachments/assets/97fbfde1-6897-4c80-b608-d4de35ca3280" />

![unnamed](https://github.com/user-attachments/assets/6295db30-e38d-4d83-8363-d81e078cf3c3)
