### PR TITLE
[Feature] Sent ECG batch as bytes via bluetooth

### DIFF
--- a/src/ble_service.cpp
+++ b/src/ble_service.cpp
@@ -96,11 +96,10 @@ BLEInitStatus initBLE() {
   return BLEInitStatus::SUCCESS;
 }
 
-void updateBLE(uint16_t ecg_data) {
+void updateBLE(uint8_t* ecg_data, int data_size) {
   if (deviceConnected && ecg_characteristic) {
-    String msg = "ECG data: " + String(ecg_data);
-    ecg_characteristic->setValue(msg.c_str());
+    ecg_characteristic->setValue(ecg_data, data_size);
     ecg_characteristic->notify();
-    Serial.println(msg);
+    Serial.printf("Sent ECG batch (%d bytes)\n", data_size);
   }
 }

--- a/src/ble_service.h
+++ b/src/ble_service.h
@@ -12,7 +12,8 @@ enum class BLEInitStatus {
 };
 
 BLEInitStatus initBLE();
-void updateBLE(uint16_t ecg_data);
+// Used an uint8_t to send the data over as binary. 
+void updateBLE(uint8_t* ecg_data, int data_size);
 extern bool deviceConnected;
 
 #endif

--- a/src/rtos_tasks.h
+++ b/src/rtos_tasks.h
@@ -4,12 +4,19 @@
 #include <Arduino.h>
 
 #define QUEUE_LENGTH 100   // Max number of samples stored in queue
-#define QUEUE_ITEM_SIZE sizeof(uint16_t)  // Storing each ECG sample as uint16_t
+#define QUEUE_ITEM_SIZE sizeof(ECGDataBatch)  // Storing each ECG sample as uint16_t
+#define ECG_BATCH_SIZE 10
 
 extern TaskHandle_t TaskECGHandle;
 extern TaskHandle_t TaskBLEHandle;
 extern volatile unsigned long currentMillis;
 extern QueueHandle_t ble_queue;
+
+// 10 samples (20 bytes) + timestamp (4 bytes) = 24 bytes
+struct ECGDataBatch  {
+    uint16_t ecg_samples[10];
+    uint32_t timestamp;
+};
 
 void TaskBLE(void* pvParameters);
 void TaskECG(void* pvParameters);


### PR DESCRIPTION
This commit does the following
- Made updateBLE more efficient by transmitting `uint8_t*` as opposed to `uint16_t` reducing the bytes transmitted by half
- Batched ECG data, meaning that instead of sending 10 notifications of ecg  data via bluetooth - we send one notification with all of the ecg data (and a timestamp!) inside.
- Created the struct `ECGDataBatch` which is the data being transmitted over bluetooth
- Verified the peripheral worked by updating the flutter client app to verify the results being transmitted properly