### PR TITLE
[Bug Fix] RTOS functions only execute when a client is connected, no more default queue overflow

### DIFF
--- a/src/ble_service.cpp
+++ b/src/ble_service.cpp
@@ -14,8 +14,7 @@ BLECharacteristic* ecg_characteristic = nullptr;
 BLECharacteristic* conn_status_characteristic = nullptr;
 
 BLEServer* pServer = nullptr;
-bool deviceConnected = false;
-
+volatile bool deviceConnected = false;
 
 class MyServerCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer* pServer) override {

--- a/src/ble_service.h
+++ b/src/ble_service.h
@@ -14,6 +14,6 @@ enum class BLEInitStatus {
 BLEInitStatus initBLE();
 // Used an uint8_t to send the data over as binary. 
 void updateBLE(uint8_t* ecg_data, int data_size);
-extern bool deviceConnected;
+extern volatile bool deviceConnected;
 
 #endif


### PR DESCRIPTION
## A huge update

I previous had an issue of the RTOS tasks in `rtos_tasks.cpp` executing without a device being connected. It seemed like a waste because we'd be calling RTOS queue functions, to ultimately be sent nowhere. 
So I fixed it. It was a pretty simple fix by making `deviceConnected` in `ble_service.` a volatile extern and sharing that param around where any RTOS functions are called. I also encountered an issue of the queue being full after running for a while - and that was due to a mismatch of the `TaskECG` producing more batches than the `TaskBLE` could consume.  I fixed it by upping the speed of which `TaskBLE` operated at.

- RTOS tasks now only execute when a client is connected
- RTOS queue no longer gets full due to TaskECG sending more messages an TaskBLE would get done. (50 to 40)


### Here is before connection
<img width="553" height="210" alt="image" src="https://github.com/user-attachments/assets/e029bbb3-62af-486a-9fe2-1b7fa509c26d" />

### Here is after connection 
<img width="453" height="207" alt="image" src="https://github.com/user-attachments/assets/ad691e12-7ab9-4a6d-ba58-6ee3831cd26b" />

I tried to get a screenshot of it saying connected then showing the dequeues, but I was too slow. I tried roughly 4 times </3