### PR TITLE
[Bug Fix] Characteristics lacked descriptor, preserved ECG morphology after type change

### DIFF
--- a/src/ble_service.cpp
+++ b/src/ble_service.cpp
@@ -76,11 +76,11 @@ BLEInitStatus initBLE() {
     return BLEInitStatus::CHARACTERISTIC_FAILURE;
   }
 
-  // Start service and enable notifications of data
-  ecgService->start();
-  statusService->start();
+// Start service and enable notifications of data
   ecg_characteristic->addDescriptor(new BLE2902());
   conn_status_characteristic->addDescriptor(new BLE2902());
+  ecgService->start();
+  statusService->start();
 
   // Begins advertising 
   BLEAdvertising* pAdvertising = BLEDevice::getAdvertising();

--- a/src/rtos_tasks.cpp
+++ b/src/rtos_tasks.cpp
@@ -3,12 +3,8 @@
 #include "Kalman_Filter.h"
 #include "ble_service.h"
 
-
-
-// SHARED VALUE between cores. Just a test.
 float ecg_sample;
 float filtered_ecg = 0.0;
-
 
 static unsigned long last_print = 0;
 int print_delay = 20;
@@ -22,29 +18,28 @@ void startTasks(EcgSharedValues* sharedValues){
   xTaskCreatePinnedToCore(TaskBLE, "BLETask", 4096,  sharedValues, 1, &TaskBLEHandle, 0);
   
   Serial.println("All setup complete. Resuming ECG task...");
-  delay(100);  // Required to give time for pin setup
+  vTaskDelay(pdMS_TO_TICKS(100)); // Required to give time for pin setup
   vTaskResume(TaskECGHandle);
+
 }
 
 void TaskBLE(void* pvParameters) {
   Serial.printf("[BLE Task] Running on core %d\n", xPortGetCoreID());
   ECGDataBatch dequeued_ecg_data;
   while (true) {
-    // Prevents task from further dequeueing any data until a client is connected.
     if (!deviceConnected) {
       Serial.println("[BLE Task] No device connected. Halting.");
-      vTaskDelay(pdMS_TO_TICKS(100)); 
+      vTaskDelay(pdMS_TO_TICKS(1000));
       continue;
     }
-    uint16_t ecg_value;
+
     if (xQueueReceive(ble_queue, &dequeued_ecg_data, portMAX_DELAY) == pdTRUE) {
-      // Send full struct (samples + timestamp) as binary. 
-      updateBLE((uint8_t*)&dequeued_ecg_data, sizeof(dequeued_ecg_data));  
-    
-      Serial.printf("[BLE Task] Dequeued RTOS queue starting at time: %lu\n", dequeued_ecg_data.timestamp);
+      updateBLE((uint8_t*)&dequeued_ecg_data, sizeof(dequeued_ecg_data));
+    } 
+    else {
+      Serial.println("[BLE Task] Queue full! Dropping batch.");
     }
 
-    // 10 ticks was chosen to give the bluetooth chip space to send 10 batches every 10 ms, and possibly sent heart rate data.
     vTaskDelay(pdMS_TO_TICKS(10));
   }
 }
@@ -53,31 +48,30 @@ void TaskECG(void* pvParameters) {
   EcgSharedValues* shared = static_cast<EcgSharedValues*>(pvParameters);
   Serial.printf("[ECG Task] Running on core %d\n", xPortGetCoreID());
 
-  const TickType_t xFrequency = pdMS_TO_TICKS(4); // 4ms period = 250 Hz
-  TickType_t xLastWakeTime = xTaskGetTickCount();
+  const TickType_t xFrequency = pdMS_TO_TICKS(4);  // 250Hz
+  TickType_t xLastWakeTime = xTaskGetTickCount(); 
   int batch_index = 0;
-
-  // Check rtos_tasks.h for member details. 
   ECGDataBatch ecg_batch;
+
   while (true) {
     int lo_plus_val = digitalRead(shared->lo_plus);
     int lo_minus_val = digitalRead(shared->lo_minus);
 
     if (lo_plus_val == HIGH || lo_minus_val == HIGH) {
       Serial.printf("Lead detection failure: LO+ %d and LO- %d\n", lo_plus_val, lo_minus_val);
-      delay(5);  
+      vTaskDelay(pdMS_TO_TICKS(5)); // Avoid using delay in RTOS. Use any vTaskDelay
     } 
     else {
       ecg_sample = (float)analogRead(shared->ecg_output_pin);
       shared->fir->process(&ecg_sample, &filtered_ecg, 1);
       float kalman_ecg = shared->kalman->update_k(filtered_ecg);
-
+      // Converts a 32 bit float into a 16 bit int to save on bluetooth bandwidth. (Half of space used)
+      uint16_t converted_sample = (uint16_t)round(kalman_ecg);
       if (millis() - last_print >= print_delay) {
         Serial.printf(">kalmanVal:%.2f\n", kalman_ecg);
+        Serial.printf(">convertedSample:%u\n", converted_sample);
         last_print = millis();
       }
-      // Converts a 32 bit float into a 16 bit int. May modify ecg_sample's type.
-      uint16_t converted_sample = (uint16_t)(kalman_ecg * 1000);
       ecg_batch.ecg_samples[batch_index++] = converted_sample;
       if (batch_index >= ECG_BATCH_SIZE) {
         ecg_batch.timestamp = millis();  // Timestamp for charting
@@ -89,6 +83,8 @@ void TaskECG(void* pvParameters) {
         else {
           Serial.println("[ECG Task] No device connected. Will store the data (IMPLEMENT LATER)");
           // Call some function to save the ECG data to a form of persistent storage.
+          // NOTE: 100 is too much. Will cause an unpaired ecg to look laggy on serial monitor.
+          // Find a different val than 100.
           vTaskDelay(pdMS_TO_TICKS(100)); 
         }
         batch_index = 0;

--- a/src/rtos_tasks.cpp
+++ b/src/rtos_tasks.cpp
@@ -48,7 +48,7 @@ void TaskECG(void* pvParameters) {
   EcgSharedValues* shared = static_cast<EcgSharedValues*>(pvParameters);
   Serial.printf("[ECG Task] Running on core %d\n", xPortGetCoreID());
 
-  const TickType_t xFrequency = pdMS_TO_TICKS(4);  // 250Hz
+  const TickType_t xFrequency = pdMS_TO_TICKS(4);  // 4ms period = 250 Hz
   TickType_t xLastWakeTime = xTaskGetTickCount(); 
   int batch_index = 0;
   ECGDataBatch ecg_batch;

--- a/src/rtos_tasks.cpp
+++ b/src/rtos_tasks.cpp
@@ -74,7 +74,7 @@ void TaskECG(void* pvParameters) {
       }
       ecg_batch.ecg_samples[batch_index++] = converted_sample;
       if (batch_index >= ECG_BATCH_SIZE) {
-        ecg_batch.timestamp = millis();  // Timestamp for charting
+        ecg_batch.timestamp = xTaskGetTickCount() * portTICK_PERIOD_MS;  // Timestamp for charting
         if(deviceConnected){
           if (xQueueSend(ble_queue, &ecg_batch, 0) != pdTRUE) {
             Serial.println("ECG queue full! Dropping batch.");


### PR DESCRIPTION
Fixed bug of characteristics not having a descriptor due to their servers starting despite explicitly. Without it, a paired client cannot receive notifications.
Also reversed ECG's value scaling before batching to better maintain ECG morphology. 